### PR TITLE
fix compile error 

### DIFF
--- a/iperf_go.go
+++ b/iperf_go.go
@@ -117,7 +117,7 @@ func IperfSetTestNumStreams(test *IperfTest, n int) {
 
 // Set bitrate in bit/sec
 func IperfSetTestRate(test *IperfTest, rate uint) {
-	C.iperf_set_test_rate(test.Ptr, C.ulonglong(rate))
+	C.iperf_set_test_rate(test.Ptr, C.ulong(rate))
 }
 
 // Set length of buffer for read/write in KB


### PR DESCRIPTION
fix: go get errors out with "cannot use _Ctype_ulonglong(rate) (type _Ctype_ulonglong) as type _Ctype_ulong in assignment"
